### PR TITLE
feat: update to Minecraft 1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.7
-yarn_mappings=1.21.7+build.2
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
 loader_version=0.16.14
 
 # Mod Properties
@@ -14,4 +14,4 @@ maven_group=dev.ysknkd.mc
 archives_base_name=mc-coordinates
 
 # Dependencies
-fabric_version=0.128.1+1.21.7
+fabric_version=0.132.0+1.21.8


### PR DESCRIPTION
## Summary
- Update Minecraft version from 1.21.7 to 1.21.8
- Update corresponding Yarn mappings and Fabric API versions

## Changes
- `minecraft_version`: 1.21.7 → 1.21.8
- `yarn_mappings`: 1.21.7+build.2 → 1.21.8+build.1
- `fabric_version`: 0.128.1+1.21.7 → 0.132.0+1.21.8

## Test plan
- [x] Build succeeds without errors
- [x] No API compatibility issues found

🤖 Generated with [Claude Code](https://claude.ai/code)