### PR TITLE
Update to Minecraft 1.21.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.10.1'
+	id 'fabric-loom' version '1.11.8'
 	id 'maven-publish'
 	id 'java'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,10 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
-loader_version=0.17.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.17.3
+loom_version=1.12-SNAPSHOT
 
 # Mod Properties
 mod_version=1.0.6-SNAPSHOT
@@ -14,4 +15,4 @@ maven_group=dev.ysknkd.mc
 archives_base_name=mc-coordinates
 
 # Dependencies
-fabric_version=0.132.0+1.21.8
+fabric_version=0.138.0+1.21.10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesListBinding.java
+++ b/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesListBinding.java
@@ -16,12 +16,16 @@ import net.minecraft.client.util.InputUtil;
 
 public class CoordinatesListBinding {
 
+    // Key binding category
+    private static final KeyBinding.Category COORDINATES_CATEGORY =
+        KeyBinding.Category.create(net.minecraft.util.Identifier.of(CoordinatesApp.MOD_ID, "main"));
+
     // Key binding for displaying the coordinates list (B key)
     private static final KeyBinding SHOW_COORDINATES_LIST_KEY = KeyBindingHelper.registerKeyBinding(
             new KeyBinding("key." + CoordinatesApp.MOD_ID + ".show_coordinates_list",
                            InputUtil.Type.KEYSYM,
                            GLFW.GLFW_KEY_B,
-                           "category." + CoordinatesApp.MOD_ID));
+                           COORDINATES_CATEGORY));
     
     private static boolean showListOnCommand = false;
     

--- a/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesListBinding.java
+++ b/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesListBinding.java
@@ -16,16 +16,12 @@ import net.minecraft.client.util.InputUtil;
 
 public class CoordinatesListBinding {
 
-    // Key binding category
-    private static final KeyBinding.Category COORDINATES_CATEGORY =
-        KeyBinding.Category.create(net.minecraft.util.Identifier.of(CoordinatesApp.MOD_ID, "main"));
-
     // Key binding for displaying the coordinates list (B key)
     private static final KeyBinding SHOW_COORDINATES_LIST_KEY = KeyBindingHelper.registerKeyBinding(
             new KeyBinding("key." + CoordinatesApp.MOD_ID + ".show_coordinates_list",
                            InputUtil.Type.KEYSYM,
                            GLFW.GLFW_KEY_B,
-                           COORDINATES_CATEGORY));
+                           CoordinatesSaveKeyBinding.COORDINATES_CATEGORY));
     
     private static boolean showListOnCommand = false;
     

--- a/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesSaveKeyBinding.java
+++ b/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesSaveKeyBinding.java
@@ -24,8 +24,8 @@ import net.minecraft.client.util.InputUtil;
  */
 public class CoordinatesSaveKeyBinding implements Consumer<MinecraftClient> {
 
-    // Key binding category
-    private static final KeyBinding.Category COORDINATES_CATEGORY =
+    // Key binding category - shared with other key bindings
+    public static final KeyBinding.Category COORDINATES_CATEGORY =
         KeyBinding.Category.create(net.minecraft.util.Identifier.of(CoordinatesApp.MOD_ID, "main"));
 
     // Key binding for saving coordinates (G key)

--- a/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesSaveKeyBinding.java
+++ b/src/client/java/dev/ysknkd/mc/coordinates/event/CoordinatesSaveKeyBinding.java
@@ -23,13 +23,17 @@ import net.minecraft.client.util.InputUtil;
  * Handles the key input for saving coordinate data (G key).
  */
 public class CoordinatesSaveKeyBinding implements Consumer<MinecraftClient> {
-    
+
+    // Key binding category
+    private static final KeyBinding.Category COORDINATES_CATEGORY =
+        KeyBinding.Category.create(net.minecraft.util.Identifier.of(CoordinatesApp.MOD_ID, "main"));
+
     // Key binding for saving coordinates (G key)
     private static final KeyBinding SAVE_COORDINATES_KEY = KeyBindingHelper.registerKeyBinding(new KeyBinding(
             "key." + CoordinatesApp.MOD_ID + ".save_coordinates",
             InputUtil.Type.KEYSYM,
             GLFW.GLFW_KEY_G,
-            "category." + CoordinatesApp.MOD_ID
+            COORDINATES_CATEGORY
     ));
     
     public static void register() {

--- a/src/client/java/dev/ysknkd/mc/coordinates/screen/DescriptionEditScreen.java
+++ b/src/client/java/dev/ysknkd/mc/coordinates/screen/DescriptionEditScreen.java
@@ -86,20 +86,20 @@ public class DescriptionEditScreen extends Screen {
 
     // Forward key input to the text field
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(net.minecraft.client.input.KeyInput input) {
         if (textField.isFocused()) {
-            textField.keyPressed(keyCode, scanCode, modifiers);
+            textField.keyPressed(input);
             return true;
         }
-        return super.keyPressed(keyCode, scanCode, modifiers);
+        return super.keyPressed(input);
     }
 
     @Override
-    public boolean charTyped(char chr, int keyCode) {
+    public boolean charTyped(net.minecraft.client.input.CharInput input) {
         if (textField.isFocused()) {
-            textField.charTyped(chr, keyCode);
+            textField.charTyped(input);
             return true;
         }
-        return super.charTyped(chr, keyCode);
+        return super.charTyped(input);
     }
 }

--- a/src/client/java/dev/ysknkd/mc/coordinates/util/IconTexture.java
+++ b/src/client/java/dev/ysknkd/mc/coordinates/util/IconTexture.java
@@ -6,7 +6,7 @@ import net.minecraft.client.texture.AbstractTexture;
 import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.texture.NativeImageBackedTexture;
 import net.minecraft.client.texture.PlayerSkinProvider;
-import net.minecraft.client.util.SkinTextures;
+import net.minecraft.entity.player.SkinTextures;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import java.util.HashMap;
@@ -109,8 +109,8 @@ public class IconTexture {
 
         // UUID からダミーの GameProfile を作成してスキンを取得
         GameProfile profile = new GameProfile(playerId, playerName);
-        SkinTextures skin = skinProvider.getSkinTextures(profile);
-        Identifier texture = skin.texture();
+        SkinTextures skin = skinProvider.supplySkinTextures(profile, false).get();
+        Identifier texture = skin.body().texturePath();
         if (texture == null) {
             return Identifier.of("minecraft", "textures/entity/steve.png");
         }

--- a/src/main/java/dev/ysknkd/mc/coordinates/network/PlayerCoordinatesBroadcaster.java
+++ b/src/main/java/dev/ysknkd/mc/coordinates/network/PlayerCoordinatesBroadcaster.java
@@ -26,7 +26,7 @@ public class PlayerCoordinatesBroadcaster implements ServerTickEvents.EndTick {
         for (ServerPlayerEntity recipient : server.getPlayerManager().getPlayerList()) {
             for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
                 if (!player.getUuid().equals(recipient.getUuid())) {
-                    String world = player.getWorld().getRegistryKey().getValue().toString();
+                    String world = player.getEntityWorld().getRegistryKey().getValue().toString();
                     PlayerCoordinatesPayload payload = new PlayerCoordinatesPayload(
                         player.getUuid(),
                         player.getX(),

--- a/src/main/java/dev/ysknkd/mc/coordinates/network/PlayerLogoutBroadcaster.java
+++ b/src/main/java/dev/ysknkd/mc/coordinates/network/PlayerLogoutBroadcaster.java
@@ -14,7 +14,7 @@ public class PlayerLogoutBroadcaster {
         // Register the logout event
         ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
             ServerPlayerEntity disconnectedPlayer = handler.getPlayer();
-            broadcastLogout(disconnectedPlayer);
+            broadcastLogout(disconnectedPlayer, server);
         });
 
         PayloadTypeRegistry.playS2C().register(PlayerLogoutPayload.ID, PlayerLogoutPayload.CODEC);
@@ -25,9 +25,9 @@ public class PlayerLogoutBroadcaster {
      *
      * @param disconnectedPlayer The player who has logged out.
      */
-    private static void broadcastLogout(ServerPlayerEntity disconnectedPlayer) {
+    private static void broadcastLogout(ServerPlayerEntity disconnectedPlayer, net.minecraft.server.MinecraftServer server) {
         PlayerLogoutPayload payload = new PlayerLogoutPayload(disconnectedPlayer.getUuid());
-        disconnectedPlayer.getServer().getPlayerManager().getPlayerList().forEach(player -> {
+        server.getPlayerManager().getPlayerList().forEach(player -> {
             if (!player.getUuid().equals(disconnectedPlayer.getUuid())) {
                 ServerPlayNetworking.send(player, payload);
             }

--- a/src/main/java/dev/ysknkd/mc/coordinates/network/ShareCoordinatesHandler.java
+++ b/src/main/java/dev/ysknkd/mc/coordinates/network/ShareCoordinatesHandler.java
@@ -23,7 +23,7 @@ public class ShareCoordinatesHandler implements PlayPayloadHandler<ShareCoordina
             ShareCoordinatesPayload outgoing = new ShareCoordinatesPayload(senderPlayer.getUuid(), payload.uuid(), payload.x(),
                     payload.y(), payload.z(), payload.description(), payload.world(), payload.pinned(), payload.icon());
 
-            for (ServerPlayerEntity target : senderPlayer.getServer().getPlayerManager().getPlayerList()) {
+            for (ServerPlayerEntity target : context.server().getPlayerManager().getPlayerList()) {
                 if (!target.getUuid().equals(senderPlayer.getUuid())) {
                     ServerPlayNetworking.send(target, outgoing);
                 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,8 @@
 		]
 	},
 	"depends": {
-		"fabricloader": ">=0.17.2",
-		"minecraft": "~1.21.8",
+		"fabricloader": ">=0.17.3",
+		"minecraft": "~1.21.10",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
## Summary
Update the mod to support Minecraft 1.21.10.

## Dependency Updates
- **Minecraft**: 1.21.8 → 1.21.10
- **Yarn mappings**: 1.21.8+build.1 → 1.21.10+build.2
- **Fabric Loader**: 0.17.2 → 0.17.3
- **Fabric API**: 0.132.0+1.21.8 → 0.138.0+1.21.10
- **Loom**: 1.10.1 → 1.11.8
- **Gradle**: 8.12.1 → 8.14.1

## API Changes Fixed
- **Entity API**: `getWorld()` renamed to `getEntityWorld()`
- **PlayerSkinProvider**: `getSkinTextures()` changed to `supplySkinTextures()`
- **SkinTextures**: Moved to `net.minecraft.entity.player` package
- **SkinTextures API**: `texture()` changed to `body().texturePath()`
- **Screen Input**: Methods now use `KeyInput` and `CharInput` types
- **KeyBinding**: Category parameter now requires `KeyBinding.Category` type

## Testing
- [x] Build succeeds without errors
- [x] All compilation errors resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)